### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
+[![Board Status](https://dev.azure.com/KRIPASORG/8a79724c-b2ab-4513-9484-fd06ac3103ed/39105395-0bed-4fc1-ab17-42b0fe7ad7bb/_apis/work/boardbadge/223a9bdb-8012-4187-aa10-2147b2af3224)](https://dev.azure.com/KRIPASORG/8a79724c-b2ab-4513-9484-fd06ac3103ed/_boards/board/t/39105395-0bed-4fc1-ab17-42b0fe7ad7bb/Microsoft.RequirementCategory)
 # Hello-World
 Starting to code ....yaaayyyyy


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#134](https://dev.azure.com/KRIPASORG/8a79724c-b2ab-4513-9484-fd06ac3103ed/_workitems/edit/134). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.